### PR TITLE
Port to Sphinx 8.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -194,7 +194,7 @@ mathjax_config = {
 }
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/', None)}
 
 
 # Deploy AutoStructify when converting markdown


### PR DESCRIPTION
The old `intersphinx_mapping` format has been removed; it must now map identifiers to (target, inventory) tuples.